### PR TITLE
Add more documentation on diffobj.format

### DIFF
--- a/R/expectations.R
+++ b/R/expectations.R
@@ -9,7 +9,7 @@
 #' \dQuote{unified} as fallback if no such option is set
 #' @param format \code{[character]} Comparison mode passed to \code{diffPrint},
 #' defaults to to using the \dQuote{diffobj.format} global option value with
-#' \dQuote{raw} as fallback if no such option is set
+#' \dQuote{ansi256} as fallback if no such option is set
 #' @param ... Passed to \code{all.equal}
 #'
 #' @return A \code{\link{tinytest}} object. A tinytest object is a

--- a/R/expectations_xl.R
+++ b/R/expectations_xl.R
@@ -19,7 +19,7 @@
 #' \dQuote{unified} as fallback if no such option is set
 #' @param format \code{[character]} Comparison mode passed to \code{diffPrint},
 #' defaults to to using the \dQuote{diffobj.format} global option value with
-#' \dQuote{raw} as fallback if no such option is set
+#' \dQuote{ansi256} as fallback if no such option is set
 #' @param ... Passed to \code{all.equal} and returned as a test attributes
 #'
 #' @return A \code{\link{tinytest}} object. A tinytest object is a

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Glad you asked:
 
 ![](https://eddelbuettel.github.io/ttdo/ttdoDemo.png)
 
+To test it out yourself, the code is in
+[demo/expect_equal_with_diff.R](https://github.com/eddelbuettel/ttdo/blob/master/demo/expect_equal_with_diff.R).
+If you don't see the same results as above, you may need to manually adjust the
+diffobj package options. Try `options(diffobj.format = "ansi256")`. See
+[Controlling Diffs and Their
+Appearance](https://cran.r-project.org/package=diffobj/vignettes/diffobj.html#controlling-diffs-and-their-appearance)
+for more details.
+
 ### How do install it?
 
 The package is now on [CRAN](https://cran.r-project.org) and can be installed

--- a/man/expect_equal_with_diff.Rd
+++ b/man/expect_equal_with_diff.Rd
@@ -35,7 +35,7 @@ defaults to using the \dQuote{diffobj.mode} global option value with
 
 \item{format}{\code{[character]} Comparison mode passed to \code{diffPrint},
 defaults to to using the \dQuote{diffobj.format} global option value with
-\dQuote{raw} as fallback if no such option is set}
+\dQuote{ansi256} as fallback if no such option is set}
 
 \item{...}{Passed to \code{all.equal}}
 }

--- a/man/expect_equal_xl.Rd
+++ b/man/expect_equal_xl.Rd
@@ -57,7 +57,7 @@ defaults to using the \dQuote{diffobj.mode} global option value with
 
 \item{format}{\code{[character]} Comparison mode passed to \code{diffPrint},
 defaults to to using the \dQuote{diffobj.format} global option value with
-\dQuote{raw} as fallback if no such option is set}
+\dQuote{ansi256} as fallback if no such option is set}
 
 \item{...}{Passed to \code{all.equal} and returned as a test attributes}
 }


### PR DESCRIPTION
Thanks for a great package. It makes it much easier to diagnose the errors from tinytest results.

It was harder for me than I had expected to format the results like that shown in the screenshot in the README. In retrospect, I think this is because ttdo combines two different packages, and thus I wasn't sure where to investigate. To assist future users, I added a small paragraph to the README to suggest that they may need to set `diffobj.format`.

Notes:
* I used the full URL to `demo/expect_equal_with_diff.R` so the the link would also work on CRAN's rendering of the README
* I also fixed a discrepancy in the documentation introduced in https://github.com/eddelbuettel/ttdo/commit/b2a07ab930c84d02426cec31414bf71fdf160714