### PR TITLE
reordering diffPrint() arguments to match current assumed order

### DIFF
--- a/R/expectations.R
+++ b/R/expectations.R
@@ -38,7 +38,7 @@ expect_equal_with_diff <- function(current, target, tol = sqrt(.Machine$double.e
     check <- all.equal(target, current, tol=tol, ...)
     equal <- isTRUE(check)
     diff  <- if (equal) NA_character_
-             else paste(as.character(diffPrint(current, target, mode=mode, format=format)),
+             else paste(as.character(diffPrint(target, current, mode=mode, format=format)),
                         collapse="\n")
     short <- if (equal) NA_character_
              else .shortdiff(current, target, tolerance=tol)


### PR DESCRIPTION
@daviddalpiaz asked me to interpret a confusing feedback message and I think it helped uncover a bug. 

```r
tinytest::expect_equal(current = NA_character_, target = NA_real_)
----- FAILED[data]: <-->
 call| tinytest::expect_equal(current = NA, target = NA)
 diff| Modes: numeric, character
 diff| target is numeric, current is character 
```

```r
> ttdo::expect_equal_with_diff(current = NA_character_, target = NA_real_)
----- FAILED[data]: <-->
 call| ttdo::expect_equal_with_diff(current = NA, target = NA)
 diff| No visible differences between objects, but objects are *not* `all.equal`:
 diff| - Modes: character, numeric
 diff| - target is character, current is numeric
 diff| < current   > target  
 diff| @@ 1 @@     @@ 1 @@   
 diff| [1] NA      [1] NA   
```

As we can see, the feedback in the `ttdo` function seems to switch target and current. I believe my PR/commit addresses this issue. When I looked at the docs for `diffobj::diffPrint()` in version 0.3.5 of `diffobj`, the example usage is `diffPrint(target, current, ...)`, this commit changes the object order to match the docs.